### PR TITLE
Fix failing tests, BC with older versions of PHP

### DIFF
--- a/src/Compoships.php
+++ b/src/Compoships.php
@@ -51,15 +51,12 @@ trait Compoships
         $connection = $this->getConnection();
 
         $grammar = match ($connection->getDriverName()) {
-            'mysql'  => new MySqlGrammar(),
-            'pgsql'  => new PostgresGrammar(),
-            'sqlite' => new SQLiteGrammar(),
-            'sqlsrv' => new SqlServerGrammar(),
+            'mysql'  => new MySqlGrammar($connection),
+            'pgsql'  => new PostgresGrammar($connection),
+            'sqlite' => new SQLiteGrammar($connection),
+            'sqlsrv' => new SqlServerGrammar($connection),
             default  => throw new RuntimeException('This database is not supported.'),
         };
-
-        $grammar->setConnection($connection);
-        $grammar = $connection->withTablePrefix($grammar);
 
         return new QueryBuilder($connection, $grammar, $connection->getPostProcessor());
     }

--- a/src/Compoships.php
+++ b/src/Compoships.php
@@ -50,13 +50,22 @@ trait Compoships
     {
         $connection = $this->getConnection();
 
-        $grammar = match ($connection->getDriverName()) {
-            'mysql'  => new MySqlGrammar($connection),
-            'pgsql'  => new PostgresGrammar($connection),
-            'sqlite' => new SQLiteGrammar($connection),
-            'sqlsrv' => new SqlServerGrammar($connection),
-            default  => throw new RuntimeException('This database is not supported.'),
-        };
+        switch ($connection->getDriverName()) {
+            case 'mysql':
+                $grammar = new MySqlGrammar($connection);
+                break;
+            case 'pgsql':
+                $grammar = new PostgresGrammar($connection);
+                break;
+            case 'sqlite':
+                $grammar = new SqliteGrammar($connection);
+                break;
+            case 'sqlsrv':
+                $grammar = new SqlServerGrammar($connection);
+                break;
+            default:
+                throw new RuntimeException('This database is not supported.');
+        }
 
         return new QueryBuilder($connection, $grammar, $connection->getPostProcessor());
     }

--- a/src/Database/Grammar/Concerns/CompileRowNumber.php
+++ b/src/Database/Grammar/Concerns/CompileRowNumber.php
@@ -10,7 +10,9 @@ trait CompileRowNumber
             return parent::compileRowNumber($partition, $orders);
         }
 
-        $columns = implode(', ', array_map(fn ($p) => $this->wrap($p), $partition));
+        $columns = implode(', ', array_map(function ($p) {
+            return $this->wrap($p);
+        }, $partition));
 
         $over = trim('partition by '.$columns.' '.$orders);
 

--- a/tests/Unit/LimitTest.php
+++ b/tests/Unit/LimitTest.php
@@ -34,13 +34,17 @@ class LimitTest extends TestCase
 
         $user = $user->fresh();
         $user->load([
-            'allocations' => fn ($query) => $query->limit(4),
+            'allocations' => function($query) {
+                $query->limit(4);
+            },
         ]);
         $this->assertCount(4, $user->allocations);
 
         $user = $user->fresh();
         $user->load([
-            'allocations' => fn ($query) => $query->limit(2),
+            'allocations' => function ($query) {
+                $query->limit(2);
+            },
         ]);
         $this->assertCount(2, $user->allocations);
     }


### PR DESCRIPTION
- grammar constructor now requires the connection, setConnection and withTablePrefix no longer exist
- old PHP does not support `match` or short `fn` closures